### PR TITLE
Fix invalid json in the CSV

### DIFF
--- a/pkg/resources/operator/migControllerExample.json
+++ b/pkg/resources/operator/migControllerExample.json
@@ -1,0 +1,12 @@
+[
+  {
+    "apiVersion":"migrations.kubevirt.io/v1alpha1",
+    "kind":"MigController",
+    "metadata": {
+      "name":"migcontroller"
+    },
+    "spec": {
+      "imagePullPolicy":"IfNotPresent"
+    }
+  }
+]

--- a/pkg/resources/operator/operator.go
+++ b/pkg/resources/operator/operator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operator
 
 import (
+	_ "embed"
 	"encoding/json"
 
 	"github.com/coreos/go-semver/semver"
@@ -321,6 +322,9 @@ type csvStrategySpec struct {
 	Deployments        []csvDeployments `json:"deployments"`
 }
 
+//go:embed migControllerExample.json
+var migControllerExample string
+
 // nolint
 func createClusterServiceVersion(data *ClusterServiceVersionData) (*csvv1.ClusterServiceVersion, error) {
 	description := `
@@ -377,20 +381,8 @@ The Kubevirt Migration Controller is an extension that provides extra capabiliti
 
 				"capabilities": "Full Lifecycle",
 				"categories":   "Storage,Virtualization",
-				"alm-examples": `
-      [
-        {
-          "apiVersion":"migrations.kubevirt.io/v1alpha1",
-          "kind":"MigController",
-          "metadata": {
-            "name":"migcontroller",
-          },
-          "spec": {
-            "imagePullPolicy":"IfNotPresent"
-          }
-        }
-      ]`,
-				"description": "Creates and maintains kubevirt migration controller deployments",
+				"alm-examples": migControllerExample,
+				"description":  "Creates and maintains kubevirt migration controller deployments",
 			},
 		},
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `alm-examples` CSV annotation, contains invalid json, with a redundant comma.

This PR fixes it by adding the migControllerExample.json file, and embed it in the CSV generator. That way, we can manage the json gist in a separate file, and find issue easily, by the IDE or jq.

Fixes #12 

**Release note**:
```release-note
None
```
