### PR TITLE
Fix e2e lane pushing to wrong repo

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -12,14 +12,14 @@ make undeploy || echo "this is fine"
 
 if [[ "$DOCKER_REPO" == "localhost" ]]; then
   port=$(./cluster-up/cli.sh ports registry | xargs)
-  DOCKER_REPO_IMAGE="${DOCKER_REPO}:${port}/${IMG}"
+  DOCKER_REMOTE_REPO="${DOCKER_REPO}:${port}"
   export BUILDAH_TLS_VERIFY=false
 else
-  DOCKER_REPO_IMAGE="${DOCKER_REPO}/${IMG}"
+  DOCKER_REMOTE_REPO="${DOCKER_REPO}"
 fi
 
 # push to local registry provided by kvci
-make buildah-manifest-push DOCKER_REPO_IMAGE="${DOCKER_REPO_IMAGE}"
+make buildah-manifest-push DOCKER_REPO="${DOCKER_REMOTE_REPO}"
 # the "cluster" (kvci VM) only understands the alias registry:5000 (which maps to localhost:${port})
 if [[ "$DOCKER_REPO" == "localhost" ]]; then
   MANIFEST_IMG="registry:5000/${IMG}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We're pushing to portless localhost:
```
buildah manifest add --arch amd64 localhost/kubevirt-migration-operator:local containers-storage:localhost:39231/kubevirt-migration-operator
4f5ac5a3bdf6e595c399ff32a09e5028690b537a1dc60e60de3d46d67a8a1936: sha256:1cf8166da8206d8d713cb56e3f86a2183895f328b16548798a40c4e1c5e856f9
buildah manifest push --tls-verify=false --all localhost/kubevirt-migration-operator:local docker://localhost/kubevirt-migration-operator:latest
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix e2e lane
```
