### PR TITLE
mig-operator: inherit TLS options from MigController TLSSecurityProfile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ import (
 
 	migrationsv1alpha1 "kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
 	"kubevirt.io/kubevirt-migration-operator/internal/controller"
+	"kubevirt.io/kubevirt-migration-operator/pkg/resources/utils"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -113,6 +114,22 @@ func main() {
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
 
+	managedTLSWatcher := utils.NewManagedTLSWatcher()
+	cryptoPolicyOpt := func(c *tls.Config) {
+		c.GetConfigForClient = func(t *tls.ClientHelloInfo) (*tls.Config, error) {
+			config := c.Clone()
+			if managedTLSWatcher != nil {
+				ctx := t.Context()
+				cc := managedTLSWatcher.GetTLSConfig(ctx)
+				config.CipherSuites = cc.CipherSuites
+				config.MinVersion = cc.MinVersion
+			}
+			return config, nil
+		}
+	}
+
+	webhookTLSOpts = append(webhookTLSOpts, cryptoPolicyOpt)
+
 	if len(webhookCertPath) > 0 {
 		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
 			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
@@ -143,7 +160,7 @@ func main() {
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,
 		SecureServing: secureMetrics,
-		TLSOpts:       tlsOpts,
+		TLSOpts:       append(tlsOpts, cryptoPolicyOpt),
 	}
 
 	if secureMetrics {
@@ -209,6 +226,12 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	managedTLSWatcher.SetCache(mgr.GetCache())
+	if err := mgr.Add(managedTLSWatcher); err != nil {
+		setupLog.Error(err, "unable to add TLS watcher to manager")
 		os.Exit(1)
 	}
 

--- a/pkg/resources/utils/tls_watcher.go
+++ b/pkg/resources/utils/tls_watcher.go
@@ -1,0 +1,174 @@
+/*
+Copyright The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sync"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
+)
+
+var (
+	tlsVersionMap = map[string]uint16{
+		"VersionTLS10": tls.VersionTLS10,
+		"VersionTLS11": tls.VersionTLS11,
+		"VersionTLS12": tls.VersionTLS12,
+		"VersionTLS13": tls.VersionTLS13,
+	}
+	cipherSuites      = tls.CipherSuites()
+	extraCipherSuites = map[string]uint16{
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES128-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES256-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-RSA-AES256-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"AES128-SHA":                    tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"AES256-SHA":                    tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"DES-CBC3-SHA":                  tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+	cipherNameToID = func() map[string]uint16 {
+		m := make(map[string]uint16, len(cipherSuites)+len(extraCipherSuites))
+		for k, v := range extraCipherSuites {
+			m[k] = v
+		}
+		for _, cs := range cipherSuites {
+			m[cs.Name] = cs.ID
+		}
+		return m
+	}()
+
+	log = ctrl.Log.WithName("managed-tls-watcher")
+)
+
+type cryptoConfig struct {
+	CipherSuites []uint16
+	MinVersion   uint16
+}
+
+type ManagedTLSWatcher struct {
+	mu            sync.RWMutex
+	cache         cache.Cache
+	defaultConfig *cryptoConfig
+	ready         bool
+}
+
+func NewManagedTLSWatcher() *ManagedTLSWatcher {
+	return &ManagedTLSWatcher{
+		defaultConfig: cryptoConfigFromSpec(nil),
+	}
+}
+
+func (m *ManagedTLSWatcher) SetCache(c cache.Cache) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cache = c
+}
+
+func (m *ManagedTLSWatcher) Start(ctx context.Context) error {
+	m.mu.RLock()
+	c := m.cache
+	m.mu.RUnlock()
+
+	if c == nil {
+		return fmt.Errorf("no cache provided for tls watcher")
+	}
+	log.Info("ManagedTLSWatcher: starting, waiting for cache sync")
+	if !c.WaitForCacheSync(ctx) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+	m.mu.Lock()
+	m.ready = true
+	m.mu.Unlock()
+	log.Info("ManagedTLSWatcher: ready")
+
+	<-ctx.Done()
+	return nil
+}
+
+func (m *ManagedTLSWatcher) NeedLeaderElection() bool {
+	return false
+}
+
+func (m *ManagedTLSWatcher) GetTLSConfig(ctx context.Context) *cryptoConfig {
+	m.mu.RLock()
+	ready := m.ready
+	c := m.cache
+	m.mu.RUnlock()
+
+	if !ready || c == nil {
+		return m.defaultConfig
+	}
+
+	list := &v1alpha1.MigControllerList{}
+	if err := c.List(ctx, list); err != nil || len(list.Items) == 0 {
+		return m.defaultConfig
+	}
+
+	return cryptoConfigFromSpec(list.Items[0].Spec.TLSSecurityProfile)
+}
+
+func cryptoConfigFromSpec(profile *v1alpha1.TLSSecurityProfile) *cryptoConfig {
+	cipherNames, minTypedTLSVersion := selectCipherSuitesAndMinTLSVersion(profile)
+	minTLSVersion, ok := tlsVersionMap[string(minTypedTLSVersion)]
+	if !ok {
+		log.Info("unknown TLS version %q, defaulting to TLS 1.2", minTypedTLSVersion)
+		minTLSVersion = tls.VersionTLS12
+	}
+	return &cryptoConfig{
+		CipherSuites: cipherSuitesIDs(cipherNames),
+		MinVersion:   minTLSVersion,
+	}
+}
+
+func selectCipherSuitesAndMinTLSVersion(profile *v1alpha1.TLSSecurityProfile) ([]string, v1alpha1.TLSProtocolVersion) {
+	if profile == nil {
+		profile = &v1alpha1.TLSSecurityProfile{
+			Type:         v1alpha1.TLSProfileIntermediateType,
+			Intermediate: &v1alpha1.IntermediateTLSProfile{},
+		}
+	}
+	if profile.Custom != nil {
+		return profile.Custom.TLSProfileSpec.Ciphers, profile.Custom.TLSProfileSpec.MinTLSVersion
+	}
+	return v1alpha1.TLSProfiles[profile.Type].Ciphers, v1alpha1.TLSProfiles[profile.Type].MinTLSVersion
+}
+
+func cipherSuitesIDs(names []string) []uint16 {
+	var ids []uint16
+	for _, name := range names {
+		if id, ok := cipherNameToID[name]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**What this PR does / why we need it**:
Previously the metrics-server and webhook would be initiated with default TLS configuration. This change makes it so the TLS configuration is updated during runtime for every request according to the MigController TLSSecurityProfile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR depends on https://github.com/kubevirt/kubevirt-migration-operator/pull/35, review only the second commit.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
mig-operator metrics-server and webhook now correctly inherit TLS options from the MigController TLSSecurityProfile. 
```
