### PR TITLE
Add sanity check in e2e for controller

### DIFF
--- a/cluster-sync/sync.sh
+++ b/cluster-sync/sync.sh
@@ -33,3 +33,14 @@ if [[ "$KUBEVIRT_PROVIDER" != "external" ]]; then
   _kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
   _kubectl wait deployment.apps/cert-manager-webhook --for condition=Available --namespace cert-manager --timeout 5m
 fi
+
+# Create a MigController CR
+_kubectl apply -f - <<EOF
+apiVersion: migrations.kubevirt.io/v1alpha1
+kind: MigController
+metadata:
+  name: migcontroller
+  namespace: kubevirt
+spec:
+  imagePullPolicy: Always
+EOF

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,9 +25,12 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	migrationsv1alpha1 "kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
 	"kubevirt.io/kubevirt-migration-operator/test/utils"
 )
 
@@ -36,8 +39,9 @@ var (
 	kubeConfig                 = flag.String("test-kubeconfig", "", "Path to the kubeconfig file")
 	migrationOperatorNamespace = flag.String("migration-operator-namespace", "kubevirt",
 		"Namespace of the migration operator")
-	kubeURL = flag.String("kubeurl", "", "URL of the kube API server")
-	kcs     *kubernetes.Clientset
+	kubeURL  = flag.String("kubeurl", "", "URL of the kube API server")
+	kcs      *kubernetes.Clientset
+	crClient crclient.Client
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -77,6 +81,11 @@ func BuildTestSuite() {
 		kcs, err = GetKubeClientFromRESTConfig(restConfig)
 		Expect(err).ToNot(HaveOccurred(), "Unable to create K8SClient")
 		Expect(kcs).ToNot(BeNil(), "K8SClient is nil")
+
+		err = migrationsv1alpha1.AddToScheme(k8sscheme.Scheme)
+		Expect(err).ToNot(HaveOccurred(), "Unable to add migrations scheme")
+		crClient, err = crclient.New(restConfig, crclient.Options{Scheme: k8sscheme.Scheme})
+		Expect(err).ToNot(HaveOccurred(), "Unable to create controller-runtime client")
 
 	})
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,7 +31,10 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+	migrationsv1alpha1 "kubevirt.io/kubevirt-migration-operator/api/v1alpha1"
 	"kubevirt.io/kubevirt-migration-operator/test/utils"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // serviceAccountName created for the project
@@ -124,6 +127,43 @@ var _ = Describe("Manager", Ordered, func() {
 				g.Expect(pods.Items[0].Status.Phase).To(Equal(corev1.PodRunning), "Incorrect operator pod status")
 			}
 			Eventually(verifyControllerUp).Should(Succeed())
+		})
+
+		It("should have the MigController CR ready", func() {
+			By("waiting for the MigController CR to be deployed")
+			verifyMigControllerReady := func(g Gomega) {
+				migControllerList := &migrationsv1alpha1.MigControllerList{}
+				g.Expect(crClient.List(context.TODO(), migControllerList,
+					crclient.InNamespace(*migrationOperatorNamespace))).To(Succeed())
+				g.Expect(migControllerList.Items).NotTo(BeEmpty(), "expected at least 1 MigController CR")
+				g.Expect(migControllerList.Items[0].Status.Phase).To(
+					Equal(sdkapi.PhaseDeployed), "MigController CR is not ready")
+			}
+			Eventually(verifyMigControllerReady).Should(Succeed())
+
+			By("verifying the migration controller pod is running and ready with zero restarts")
+			pods, err := kcs.CoreV1().Pods(*migrationOperatorNamespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app=kubevirt-migration-controller",
+			})
+			Expect(err).NotTo(HaveOccurred(), "Failed to list migration controller pods")
+			Expect(pods.Items).NotTo(BeEmpty(), "expected at least 1 migration controller pod")
+			for _, pod := range pods.Items {
+				Expect(pod.Status.Phase).To(Equal(corev1.PodRunning),
+					fmt.Sprintf("pod %s is in phase %s, expected Running", pod.Name, pod.Status.Phase))
+
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == corev1.PodReady {
+						Expect(cond.Status).To(Equal(corev1.ConditionTrue),
+							fmt.Sprintf("pod %s Ready condition is %s, expected True", pod.Name, cond.Status))
+					}
+				}
+
+				for _, cs := range pod.Status.ContainerStatuses {
+					Expect(cs.RestartCount).To(BeZero(),
+						fmt.Sprintf("container %s in pod %s has %d restarts",
+							cs.Name, pod.Name, cs.RestartCount))
+				}
+			}
 		})
 
 		It("should ensure the metrics endpoint is serving metrics", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We could benefit from general readiness assertion in a "real" environment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends on https://github.com/kubevirt/project-infra/pull/4954

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
