### PR TITLE
Add network policies to Migration Operator

### DIFF
--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -7,13 +7,12 @@ metadata:
   labels:
     app.kubernetes.io/name: kubevirt-migration-operator
     app.kubernetes.io/managed-by: kustomize
-  name: allow-metrics-traffic
+  name: migration-operator-allow-ingress-to-metrics
   namespace: system
 spec:
   podSelector:
     matchLabels:
-      control-plane: operator
-      app.kubernetes.io/name: kubevirt-migration-operator
+      prometheus.migrations.kubevirt.io: "true"
   policyTypes:
     - Ingress
   ingress:
@@ -21,7 +20,7 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            metrics: enabled  # Only from namespaces with this label
+            metrics: enabled # Only from namespaces with this label
       ports:
         - port: 8443
           protocol: TCP

--- a/config/operator/operator.yaml
+++ b/config/operator/operator.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         control-plane: operator
         app.kubernetes.io/name: kubevirt-migration-operator
+        prometheus.migrations.kubevirt.io: "true"
+        np.kubevirt.io/allow-access-cluster-services: "true"
     spec:
       securityContext:
         # Projects are configured by default to adhere to the "restricted" Pod Security Standards.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -37,4 +37,11 @@ const (
 	ComponentLabel = "migrations.kubevirt.io"
 	// ConfigMapName is the name of the configmap that owns controller resources
 	ConfigMapName = "kubevirt-migration-controller-config"
+
+	// AllowAccessClusterServicesNPLabel is a pod label to be set by virt-components to indicate that they require
+	// access to cluster services otherwise blocked by a strict network policy (NP).
+	// This label will be applied to the following Migration Operator pods by default:
+	// - kubevirt-migration-controller
+	// - kubevirt-migration-operator
+	AllowAccessClusterServicesNPLabel string = "np.kubevirt.io/allow-access-cluster-services"
 )

--- a/pkg/resources/namespaced/controller.go
+++ b/pkg/resources/namespaced/controller.go
@@ -23,11 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk"
 	"kubevirt.io/kubevirt-migration-operator/pkg/common"
 	utils "kubevirt.io/kubevirt-migration-operator/pkg/resources/utils"
 )
@@ -137,12 +139,12 @@ func createControllerDeployment(controllerImage, verbosity, pullPolicy, priority
 	}
 	container.Args = append(container.Args, "--leader-elect", "--health-probe-bind-address=:8081",
 		"--metrics-bind-address=:8443")
-	labels := mergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{
-		common.PrometheusLabelKey: common.PrometheusLabelValue,
-	})
-	// Add label for pod affinity
-	deployment.SetLabels(labels)
-	deployment.Spec.Template.SetLabels(labels)
+	sdk.MergeLabelsAndAnnotations(&v1.ObjectMeta{
+		Labels: map[string]string{
+			common.PrometheusLabelKey:                common.PrometheusLabelValue,
+			common.AllowAccessClusterServicesNPLabel: "true",
+		},
+	}, &deployment.Spec.Template.ObjectMeta)
 	if deployment.Spec.Template.Annotations == nil {
 		deployment.Spec.Template.Annotations = make(map[string]string)
 	}
@@ -225,19 +227,6 @@ func kubevirtCAVolume() corev1.Volume {
 			},
 		},
 	}
-}
-
-// mergeLabels copies source labels to destination (overwrites existing labels)
-func mergeLabels(src, dest map[string]string) map[string]string {
-	if dest == nil {
-		dest = map[string]string{}
-	}
-
-	for k, v := range src {
-		dest[k] = v
-	}
-
-	return dest
 }
 
 func createPrometheusService() *corev1.Service {

--- a/pkg/resources/namespaced/factory.go
+++ b/pkg/resources/namespaced/factory.go
@@ -50,6 +50,10 @@ var factoryFunctions = map[string]factoryFunc{
 	"controller": createControllerResources,
 }
 
+var additionalFactoryFunctions = map[string]factoryFunc{
+	"networkpolicies": createNetworkPolicies,
+}
+
 // CreateAllResources creates all namespaced resources
 func CreateAllResources(args *FactoryArgs) ([]client.Object, error) {
 	var resources []client.Object
@@ -65,7 +69,7 @@ func CreateAllResources(args *FactoryArgs) ([]client.Object, error) {
 
 // CreateResourceGroup creates namespaced resources for a specific group/component
 func CreateResourceGroup(group string, args *FactoryArgs) ([]client.Object, error) {
-	f, ok := factoryFunctions[group]
+	f, ok := getFactoryFunc(group)
 	if !ok {
 		return nil, fmt.Errorf("group %s does not exist", group)
 	}
@@ -75,6 +79,14 @@ func CreateResourceGroup(group string, args *FactoryArgs) ([]client.Object, erro
 		assignNamspaceIfMissing(resource, args.Namespace)
 	}
 	return resources, nil
+}
+
+func getFactoryFunc(group string) (factoryFunc, bool) {
+	if f, ok := factoryFunctions[group]; ok {
+		return f, true
+	}
+	f, ok := additionalFactoryFunctions[group]
+	return f, ok
 }
 
 func assignNamspaceIfMissing(resource client.Object, namespace string) {

--- a/pkg/resources/namespaced/networkpolicies.go
+++ b/pkg/resources/namespaced/networkpolicies.go
@@ -1,0 +1,75 @@
+/*
+Copyright The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaced
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"kubevirt.io/kubevirt-migration-operator/pkg/common"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	allowIngressToMetrics = "migration-operator-allow-ingress-to-metrics"
+)
+
+func createNetworkPolicies(args *FactoryArgs) []client.Object {
+	return []client.Object{
+		newIngressToMetricsNP(args.Namespace),
+	}
+}
+
+func newNetworkPolicy(namespace, name string, spec *networkv1.NetworkPolicySpec) *networkv1.NetworkPolicy {
+	return &networkv1.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "networking.k8s.io/v1",
+			Kind:       "NetworkPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: *spec,
+	}
+}
+
+func newIngressToMetricsNP(namespace string) *networkv1.NetworkPolicy {
+	return newNetworkPolicy(
+		namespace,
+		allowIngressToMetrics,
+		&networkv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{common.PrometheusLabelKey: common.PrometheusLabelValue},
+			},
+			PolicyTypes: []networkv1.PolicyType{networkv1.PolicyTypeIngress},
+			Ingress: []networkv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkv1.NetworkPolicyPort{
+						{
+							Port:     ptr.To(intstr.FromInt32(8443)),
+							Protocol: ptr.To(corev1.ProtocolTCP),
+						},
+					},
+				},
+			},
+		},
+	)
+}

--- a/pkg/resources/utils/deploy.go
+++ b/pkg/resources/utils/deploy.go
@@ -25,6 +25,7 @@ import (
 	secv1 "github.com/openshift/api/security/v1"
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+	"kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk"
 	utils "kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources"
 	"kubevirt.io/kubevirt-migration-operator/pkg/common"
 )
@@ -145,10 +146,12 @@ func CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAcco
 	}
 	deployment := ResourceBuilder.CreateOperatorDeployment(name, namespace, matchKey,
 		matchValue, serviceAccount, numReplicas, podSpec)
-	// labels := util.MergeLabels(deployment.Spec.Template.GetLabels(), map[string]string{PrometheusLabelKey:
-	//  PrometheusLabelValue, CDIComponentLabel: CDIOperatorName})
-	// deployment.SetLabels(labels)
-	// deployment.Spec.Template.SetLabels(labels)
+	sdk.MergeLabelsAndAnnotations(&metav1.ObjectMeta{
+		Labels: map[string]string{
+			common.PrometheusLabelKey:                common.PrometheusLabelValue,
+			common.AllowAccessClusterServicesNPLabel: common.AllowAccessClusterServicesNPLabel,
+		},
+	}, &deployment.Spec.Template.ObjectMeta)
 	if deployment.Spec.Template.Annotations == nil {
 		deployment.Spec.Template.Annotations = make(map[string]string)
 	}

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"kubevirt.io/kubevirt-migration-operator/pkg/resources/namespaced"
 	operator "kubevirt.io/kubevirt-migration-operator/pkg/resources/operator"
 )
 
@@ -43,7 +44,10 @@ var (
 
 	operatorImage   = flag.String("operator-image", "", "")
 	controllerImage = flag.String("controller-image", "", "")
-	dumpCRDs        = flag.Bool("dump-crds", false, "optional - dumps migration operator related crd manifests to stdout")
+	dumpCRDs        = flag.Bool("dump-crds", false,
+		"optional - dumps migration operator related crd manifests to stdout")
+	dumpNetworkPolicies = flag.Bool("dump-network-policies", false,
+		"optional - dumps migration operator related network policies")
 )
 
 //go:embed assets/migrations.kubevirt.io_migcontrollers.yaml
@@ -85,6 +89,20 @@ func main() {
 		_, err = io.Copy(os.Stdout, bytes.NewReader(migControllersCRD))
 		if err != nil {
 			panic(err)
+		}
+	}
+
+	if *dumpNetworkPolicies {
+		cdiNps, err := namespaced.CreateResourceGroup("networkpolicies", &namespaced.FactoryArgs{
+			Namespace: *namespace,
+		})
+		if err != nil {
+			panic(err)
+		}
+		for _, np := range cdiNps {
+			if err = marshallObject(np, os.Stdout); err != nil {
+				panic(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR extends Migration Operator to allow an optional generation and deployment of network policies that generally allow only the traffic patterns required by Migration Operator's components, those being:
- kubevirt-migration-operator
- kubevirt-migration-controller

This enables support for both CSV generation and kustomize (and also adapts the necessary labels/selectors). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added network policies as part of the csv-generator tool and adjusted kustomize network policies.
```
