### PR TITLE
Ensure generated deployment matches upstream controller deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.3
+	github.com/google/go-cmp v0.7.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
@@ -64,7 +65,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.22.0 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/pkg/resources/namespaced/controller.go
+++ b/pkg/resources/namespaced/controller.go
@@ -24,6 +24,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
@@ -197,8 +198,32 @@ func createControllerDeployment(controllerImage, verbosity, pullPolicy, priority
 		},
 	}
 
+	// Mount the kubevirt CA certificate so the controller can access metrics from virt-handler pods
+	container.VolumeMounts = []corev1.VolumeMount{
+		{
+			Name:      "kubevirt-ca-configmap",
+			MountPath: "/etc/ssl/certs/kubevirt-ca",
+			ReadOnly:  true,
+		},
+	}
+
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
+	// Ensure the controller has access to the Kubevirt CA certificate, this is needed so the controller
+	// can get metrics from the virt-handler pods.
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, kubevirtCAVolume())
+	deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To[int64](10)
 	return deployment
+}
+
+func kubevirtCAVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: "kubevirt-ca-configmap",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "kubevirt-ca"},
+			},
+		},
+	}
 }
 
 // mergeLabels copies source labels to destination (overwrites existing labels)

--- a/pkg/resources/namespaced/controller_test.go
+++ b/pkg/resources/namespaced/controller_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaced
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+)
+
+const (
+	testKubevirtCAVolumeName = "kubevirt-ca-configmap"
+)
+
+func TestNamespaced(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Namespaced Resources Suite")
+}
+
+var _ = Describe("Controller Deployment", func() {
+	DescribeTable("should match controller configuration",
+		func(priorityClass string, nodePlacement *sdkapi.NodePlacement) {
+			deployment := createControllerDeployment(
+				"test-image:latest",
+				"2",
+				"IfNotPresent",
+				priorityClass,
+				nodePlacement,
+			)
+
+			Expect(deployment).NotTo(BeNil())
+			Expect(deployment.Spec.Template.Spec.Volumes).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+
+			container := deployment.Spec.Template.Spec.Containers[0]
+
+			// Verify kubevirt-ca volume
+			var caVolume *corev1.Volume
+			for i, volume := range deployment.Spec.Template.Spec.Volumes {
+				if volume.Name == testKubevirtCAVolumeName {
+					caVolume = &deployment.Spec.Template.Spec.Volumes[i]
+					break
+				}
+			}
+			Expect(caVolume).NotTo(BeNil(), "kubevirt-ca-configmap volume should be present")
+			Expect(caVolume.VolumeSource.ConfigMap).NotTo(BeNil(), "volume should be backed by a ConfigMap")
+			Expect(caVolume.VolumeSource.ConfigMap.Name).To(Equal("kubevirt-ca"), "ConfigMap name should be kubevirt-ca")
+
+			// Verify volumeMount on container
+			Expect(container.VolumeMounts).To(HaveLen(1))
+			Expect(container.VolumeMounts[0].Name).To(Equal(testKubevirtCAVolumeName))
+			Expect(container.VolumeMounts[0].MountPath).To(Equal("/etc/ssl/certs/kubevirt-ca"))
+			Expect(container.VolumeMounts[0].ReadOnly).To(BeTrue())
+
+			// Verify resource requests
+			Expect(container.Resources.Requests).NotTo(BeNil())
+			Expect(container.Resources.Requests.Cpu().String()).To(Equal("100m"))
+			Expect(container.Resources.Requests.Memory().String()).To(Equal("150Mi"))
+
+			// Verify terminationGracePeriodSeconds
+			Expect(deployment.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(BeNil())
+			Expect(*deployment.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(int64(10)))
+		},
+		Entry("with default configuration", "", &sdkapi.NodePlacement{}),
+		Entry("with priority class", "system-cluster-critical", &sdkapi.NodePlacement{}),
+		Entry("with custom node placement", "", &sdkapi.NodePlacement{
+			NodeSelector: map[string]string{
+				"custom-label": "custom-value",
+			},
+		}),
+		Entry("with both priority class and node placement", "system-cluster-critical", &sdkapi.NodePlacement{
+			NodeSelector: map[string]string{
+				"custom-label": "custom-value",
+			},
+		}),
+	)
+
+	Context("kubevirtCAVolume function", func() {
+		It("should return a properly configured volume", func() {
+			volume := kubevirtCAVolume()
+
+			Expect(volume.Name).To(Equal(testKubevirtCAVolumeName))
+			Expect(volume.VolumeSource.ConfigMap).NotTo(BeNil())
+			Expect(volume.VolumeSource.ConfigMap.LocalObjectReference.Name).To(Equal("kubevirt-ca"))
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If the kubevirt-migration-controller deployment is updated, the operator deployment should be updated to match. This commit makes sure we are currently synchronized.

Added a test to ensure any drift is detected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed controller configuration drift between operator and controller
```
