### PR TITLE
Follow up API change in name validation

### DIFF
--- a/pkg/resources/crds_generated.go
+++ b/pkg/resources/crds_generated.go
@@ -303,9 +303,9 @@ spec:
                         properties:
                           name:
                             description: The name of the virtual machine to migrate.
-                            maxLength: 63
+                            maxLength: 253
                             minLength: 1
-                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           targetMigrationPVCs:
                             description: A list of PVCs associated with the VirtualMachine
@@ -338,9 +338,9 @@ spec:
                                       description: The name of the destination PVC.
                                         If not provided, the PVC will be named after
                                         the source PVC with a "-mig-xxxx" suffix.
-                                      maxLength: 63
+                                      maxLength: 253
                                       minLength: 1
-                                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     storageClassName:
                                       description: The target storage class to use
@@ -456,9 +456,9 @@ spec:
                         properties:
                           name:
                             description: The name of the virtual machine to migrate.
-                            maxLength: 63
+                            maxLength: 253
                             minLength: 1
-                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           sourcePVCs:
                             description: A list of source PVCs currently used by the
@@ -954,9 +954,9 @@ spec:
                                       description: The name of the destination PVC.
                                         If not provided, the PVC will be named after
                                         the source PVC with a "-mig-xxxx" suffix.
-                                      maxLength: 63
+                                      maxLength: 253
                                       minLength: 1
-                                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     storageClassName:
                                       description: The target storage class to use
@@ -1033,9 +1033,9 @@ spec:
                         properties:
                           name:
                             description: The name of the virtual machine to migrate.
-                            maxLength: 63
+                            maxLength: 253
                             minLength: 1
-                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           sourcePVCs:
                             description: A list of source PVCs currently used by the
@@ -1531,9 +1531,9 @@ spec:
                                       description: The name of the destination PVC.
                                         If not provided, the PVC will be named after
                                         the source PVC with a "-mig-xxxx" suffix.
-                                      maxLength: 63
+                                      maxLength: 253
                                       minLength: 1
-                                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     storageClassName:
                                       description: The target storage class to use
@@ -1575,9 +1575,9 @@ spec:
                         properties:
                           name:
                             description: The name of the virtual machine to migrate.
-                            maxLength: 63
+                            maxLength: 253
                             minLength: 1
-                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           sourcePVCs:
                             description: A list of source PVCs currently used by the
@@ -2073,9 +2073,9 @@ spec:
                                       description: The name of the destination PVC.
                                         If not provided, the PVC will be named after
                                         the source PVC with a "-mig-xxxx" suffix.
-                                      maxLength: 63
+                                      maxLength: 253
                                       minLength: 1
-                                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     storageClassName:
                                       description: The target storage class to use
@@ -2117,9 +2117,9 @@ spec:
                         properties:
                           name:
                             description: The name of the virtual machine to migrate.
-                            maxLength: 63
+                            maxLength: 253
                             minLength: 1
-                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           sourcePVCs:
                             description: A list of source PVCs currently used by the
@@ -2615,9 +2615,9 @@ spec:
                                       description: The name of the destination PVC.
                                         If not provided, the PVC will be named after
                                         the source PVC with a "-mig-xxxx" suffix.
-                                      maxLength: 63
+                                      maxLength: 253
                                       minLength: 1
-                                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     storageClassName:
                                       description: The target storage class to use
@@ -2662,9 +2662,9 @@ spec:
                         properties:
                           name:
                             description: The name of the virtual machine to migrate.
-                            maxLength: 63
+                            maxLength: 253
                             minLength: 1
-                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           sourcePVCs:
                             description: A list of source PVCs currently used by the
@@ -3160,9 +3160,9 @@ spec:
                                       description: The name of the destination PVC.
                                         If not provided, the PVC will be named after
                                         the source PVC with a "-mig-xxxx" suffix.
-                                      maxLength: 63
+                                      maxLength: 253
                                       minLength: 1
-                                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     storageClassName:
                                       description: The target storage class to use
@@ -3477,9 +3477,9 @@ spec:
                   properties:
                     name:
                       description: The name of the virtual machine to migrate.
-                      maxLength: 63
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     targetMigrationPVCs:
                       description: A list of PVCs associated with the VirtualMachine
@@ -3510,9 +3510,9 @@ spec:
                                 description: The name of the destination PVC. If not
                                   provided, the PVC will be named after the source
                                   PVC with a "-mig-xxxx" suffix.
-                                maxLength: 63
+                                maxLength: 253
                                 minLength: 1
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               storageClassName:
                                 description: The target storage class to use for the
@@ -3565,9 +3565,9 @@ spec:
                   properties:
                     name:
                       description: The name of the virtual machine to migrate.
-                      maxLength: 63
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     sourcePVCs:
                       description: A list of source PVCs currently used by the VirtualMachine.
@@ -4046,9 +4046,9 @@ spec:
                                 description: The name of the destination PVC. If not
                                   provided, the PVC will be named after the source
                                   PVC with a "-mig-xxxx" suffix.
-                                maxLength: 63
+                                maxLength: 253
                                 minLength: 1
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               storageClassName:
                                 description: The target storage class to use for the
@@ -4125,9 +4125,9 @@ spec:
                   properties:
                     name:
                       description: The name of the virtual machine to migrate.
-                      maxLength: 63
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     sourcePVCs:
                       description: A list of source PVCs currently used by the VirtualMachine.
@@ -4606,9 +4606,9 @@ spec:
                                 description: The name of the destination PVC. If not
                                   provided, the PVC will be named after the source
                                   PVC with a "-mig-xxxx" suffix.
-                                maxLength: 63
+                                maxLength: 253
                                 minLength: 1
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               storageClassName:
                                 description: The target storage class to use for the
@@ -4649,9 +4649,9 @@ spec:
                   properties:
                     name:
                       description: The name of the virtual machine to migrate.
-                      maxLength: 63
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     sourcePVCs:
                       description: A list of source PVCs currently used by the VirtualMachine.
@@ -5130,9 +5130,9 @@ spec:
                                 description: The name of the destination PVC. If not
                                   provided, the PVC will be named after the source
                                   PVC with a "-mig-xxxx" suffix.
-                                maxLength: 63
+                                maxLength: 253
                                 minLength: 1
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               storageClassName:
                                 description: The target storage class to use for the
@@ -5174,9 +5174,9 @@ spec:
                   properties:
                     name:
                       description: The name of the virtual machine to migrate.
-                      maxLength: 63
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     sourcePVCs:
                       description: A list of source PVCs currently used by the VirtualMachine.
@@ -5655,9 +5655,9 @@ spec:
                                 description: The name of the destination PVC. If not
                                   provided, the PVC will be named after the source
                                   PVC with a "-mig-xxxx" suffix.
-                                maxLength: 63
+                                maxLength: 253
                                 minLength: 1
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               storageClassName:
                                 description: The target storage class to use for the
@@ -5699,9 +5699,9 @@ spec:
                   properties:
                     name:
                       description: The name of the virtual machine to migrate.
-                      maxLength: 63
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     sourcePVCs:
                       description: A list of source PVCs currently used by the VirtualMachine.
@@ -6180,9 +6180,9 @@ spec:
                                 description: The name of the destination PVC. If not
                                   provided, the PVC will be named after the source
                                   PVC with a "-mig-xxxx" suffix.
-                                maxLength: 63
+                                maxLength: 253
                                 minLength: 1
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               storageClassName:
                                 description: The target storage class to use for the


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt-migration-controller/pull/69

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
