### PR TITLE
Add single ns migration RBAC to aggregated admin role

### DIFF
--- a/internal/controller/migcontroller_controller_test.go
+++ b/internal/controller/migcontroller_controller_test.go
@@ -153,7 +153,7 @@ var _ = Describe("MigController Controller", func() {
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 
-		It("should successfully create aggregated cluster role", func() {
+		DescribeTable("check all expected aggregated cluster role rules exist", func(role string, rules []rbacv1.PolicyRule) {
 			resource := &migrationsv1alpha1.MigController{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
@@ -165,11 +165,55 @@ var _ = Describe("MigController Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(defaultResult))
-
 			clusterRole := &rbacv1.ClusterRole{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "migrations.kubevirt.io:view"}, clusterRole)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(clusterRole.Rules).To(ContainElements(
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("migrations.kubevirt.io:%s", role)}, clusterRole)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(clusterRole.Rules).To(ContainElements(rules))
+		},
+			Entry("for admin", "admin",
+				[]rbacv1.PolicyRule{
+					{
+						APIGroups: []string{
+							"migrations.kubevirt.io",
+						},
+						Resources: []string{
+							"virtualmachinestoragemigrations",
+							"virtualmachinestoragemigrationplans",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+							"create",
+							"update",
+							"delete",
+							"patch",
+						},
+					},
+				}),
+			Entry("for edit", "edit",
+				[]rbacv1.PolicyRule{
+					{
+						APIGroups: []string{
+							"migrations.kubevirt.io",
+						},
+						Resources: []string{
+							"virtualmachinestoragemigrations",
+							"virtualmachinestoragemigrationplans",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+							"create",
+							"update",
+							"delete",
+							"patch",
+						},
+					},
+				}),
+			Entry("for view", "view",
 				[]rbacv1.PolicyRule{
 					{
 						APIGroups: []string{
@@ -187,9 +231,8 @@ var _ = Describe("MigController Controller", func() {
 							"watch",
 						},
 					},
-				},
-			))
-		})
+				}),
+		)
 	})
 })
 

--- a/pkg/resources/cluster/rbac.go
+++ b/pkg/resources/cluster/rbac.go
@@ -33,9 +33,26 @@ func createAggregateClusterRoles(_ *FactoryArgs) []client.Object {
 }
 
 func getAdminPolicyRules() []rbacv1.PolicyRule {
-	// leaving this here so we have optionality in the future for other resources
-	// currently we follow the kubevirt model where only admin can migrate
-	return []rbacv1.PolicyRule{}
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"migrations.kubevirt.io",
+			},
+			Resources: []string{
+				"virtualmachinestoragemigrations",
+				"virtualmachinestoragemigrationplans",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"delete",
+				"patch",
+			},
+		},
+	}
 }
 
 func getEditPolicyRules() []rbacv1.PolicyRule {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are okay with ns admin doing storage live migrations
in their namespace because nothing stops them from
doing that at the kubevirt level at this moment in time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Add single ns migration RBAC to aggregated admin role
```
