### PR TITLE
Specify default config map mode bits explicitly to avoid spam

### DIFF
--- a/pkg/resources/namespaced/controller.go
+++ b/pkg/resources/namespaced/controller.go
@@ -222,6 +222,7 @@ func kubevirtCAVolume() corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "kubevirt-ca"},
+				DefaultMode:          ptr.To(corev1.ConfigMapVolumeSourceDefaultMode),
 			},
 		},
 	}

--- a/pkg/resources/namespaced/controller_test.go
+++ b/pkg/resources/namespaced/controller_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Controller Deployment", func() {
 			Expect(caVolume).NotTo(BeNil(), "kubevirt-ca-configmap volume should be present")
 			Expect(caVolume.VolumeSource.ConfigMap).NotTo(BeNil(), "volume should be backed by a ConfigMap")
 			Expect(caVolume.VolumeSource.ConfigMap.Name).To(Equal("kubevirt-ca"), "ConfigMap name should be kubevirt-ca")
+			Expect(caVolume.VolumeSource.ConfigMap.DefaultMode).To(HaveValue(Equal(corev1.ConfigMapVolumeSourceDefaultMode)))
 
 			// Verify volumeMount on container
 			Expect(container.VolumeMounts).To(HaveLen(1))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If we don't specify the default, we get into a update hotloop
over the defaulting done by the platform.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://redhat.atlassian.net/browse/OCPBUGS-85383

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: CNV migcontroller generates excessive UpdateResourceSuccess events
```
