### PR TITLE
Add storagemigrate cluster roles for admin-assignable RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -183,6 +183,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - migrations.kubevirt.io
   resources:

--- a/internal/controller/migcontroller_controller_test.go
+++ b/internal/controller/migcontroller_controller_test.go
@@ -153,7 +153,7 @@ var _ = Describe("MigController Controller", func() {
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 
-		It("should successfully create aggregated cluster role", func() {
+		DescribeTable("check all expected cluster role rules exist", func(role string, rules []rbacv1.PolicyRule) {
 			resource := &migrationsv1alpha1.MigController{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
@@ -165,11 +165,17 @@ var _ = Describe("MigController Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(defaultResult))
-
 			clusterRole := &rbacv1.ClusterRole{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: "migrations.kubevirt.io:view"}, clusterRole)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(clusterRole.Rules).To(ContainElements(
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("migrations.kubevirt.io:%s", role)}, clusterRole)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(clusterRole.Rules).To(HaveExactElements(rules))
+		},
+			Entry("for admin", "admin",
+				[]rbacv1.PolicyRule{}),
+			Entry("for edit", "edit",
+				[]rbacv1.PolicyRule{}),
+			Entry("for view", "view",
 				[]rbacv1.PolicyRule{
 					{
 						APIGroups: []string{
@@ -187,9 +193,54 @@ var _ = Describe("MigController Controller", func() {
 							"watch",
 						},
 					},
-				},
-			))
-		})
+				}),
+			Entry("for storagemigrate", "storagemigrate",
+				[]rbacv1.PolicyRule{
+					{
+						APIGroups: []string{
+							"migrations.kubevirt.io",
+						},
+						Resources: []string{
+							"virtualmachinestoragemigrations",
+							"virtualmachinestoragemigrationplans",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+							"create",
+							"update",
+							"patch",
+							"delete",
+							"deletecollection",
+						},
+					},
+				}),
+			Entry("for storagemigrate-multins", "storagemigrate-multins",
+				[]rbacv1.PolicyRule{
+					{
+						APIGroups: []string{
+							"migrations.kubevirt.io",
+						},
+						Resources: []string{
+							"virtualmachinestoragemigrations",
+							"virtualmachinestoragemigrationplans",
+							"multinamespacevirtualmachinestoragemigrations",
+							"multinamespacevirtualmachinestoragemigrationplans",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+							"create",
+							"update",
+							"patch",
+							"delete",
+							"deletecollection",
+						},
+					},
+				}),
+		)
 	})
 })
 

--- a/pkg/resources/cluster/factory.go
+++ b/pkg/resources/cluster/factory.go
@@ -41,9 +41,10 @@ type factoryFunc func(*FactoryArgs) []client.Object
 type factoryFuncMap map[string]factoryFunc
 
 var staticFactoryFunctions = factoryFuncMap{
-	"controller-rbac": createControllerResources,
-	"crd-resources":   createCRDResources,
-	"aggregate-roles": createAggregateClusterRoles,
+	"controller-rbac":      createControllerResources,
+	"crd-resources":        createCRDResources,
+	"aggregate-roles":      createAggregateClusterRoles,
+	"storagemigrate-roles": createStorageMigrationClusterRoles,
 }
 
 func createCRDResources(args *FactoryArgs) []client.Object {

--- a/pkg/resources/cluster/rbac.go
+++ b/pkg/resources/cluster/rbac.go
@@ -32,6 +32,15 @@ func createAggregateClusterRoles(_ *FactoryArgs) []client.Object {
 	}
 }
 
+func createStorageMigrationClusterRoles(_ *FactoryArgs) []client.Object {
+	return []client.Object{
+		utils.ResourceBuilder.CreateClusterRole(
+			"migrations.kubevirt.io:storagemigrate", getStorageMigratePolicyRules()),
+		utils.ResourceBuilder.CreateClusterRole(
+			"migrations.kubevirt.io:storagemigrate-multins", getStorageMigrateMultinsPolicyRules()),
+	}
+}
+
 func getAdminPolicyRules() []rbacv1.PolicyRule {
 	// leaving this here so we have optionality in the future for other resources
 	// currently we follow the kubevirt model where only admin can migrate
@@ -59,6 +68,56 @@ func getViewPolicyRules() []rbacv1.PolicyRule {
 				"get",
 				"list",
 				"watch",
+			},
+		},
+	}
+}
+
+func getStorageMigratePolicyRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"migrations.kubevirt.io",
+			},
+			Resources: []string{
+				"virtualmachinestoragemigrations",
+				"virtualmachinestoragemigrationplans",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"patch",
+				"delete",
+				"deletecollection",
+			},
+		},
+	}
+}
+
+func getStorageMigrateMultinsPolicyRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"migrations.kubevirt.io",
+			},
+			Resources: []string{
+				"virtualmachinestoragemigrations",
+				"virtualmachinestoragemigrationplans",
+				"multinamespacevirtualmachinestoragemigrations",
+				"multinamespacevirtualmachinestoragemigrationplans",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+				"create",
+				"update",
+				"patch",
+				"delete",
+				"deletecollection",
 			},
 		},
 	}

--- a/tools/csv-generator/assets/rbac.yaml
+++ b/tools/csv-generator/assets/rbac.yaml
@@ -272,6 +272,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - migrations.kubevirt.io
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add two non-aggregated ClusterRoles that cluster admins can explicitly
bind to eligible users for storage migration operations:

- migrations.kubevirt.io:storagemigrate — single-namespace storage
  migration (bind via RoleBinding)
- migrations.kubevirt.io:storagemigrate-multins — multi-namespace
  storage migration, superset of single-ns (bind via ClusterRoleBinding)

Neither role is aggregated into the built-in admin/edit roles, so they
must be explicitly assigned. This follows similar RBAC hardening
considerations as https://github.com/kubevirt/kubevirt/pull/13497
which restricted live migration permissions in KubeVirt to explicitly
granted roles.

Usage examples:
Grant user1 storage migration access in namespace "my-ns"
```
kubectl create rolebinding my-storagemigrate \
    --clusterrole=migrations.kubevirt.io:storagemigrate \
    --user=user1 -n my-ns
```
Grant user1 cluster-wide multi-namespace storage migration access
```
kubectl create clusterrolebinding my-storagemigrate-multins \
    --clusterrole=migrations.kubevirt.io:storagemigrate-multins \
    --user=user1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://redhat.atlassian.net/browse/CNV-86880

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The new `kubevirt.io:storagemigrate` clusterroles can be bound by cluster admins to the users that need to manage storage live migrations
```
