### PR TITLE
Fix operator deployment selector mutation on upgrade

### DIFF
--- a/staging/src/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources/resources.go
+++ b/staging/src/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources/resources.go
@@ -37,8 +37,9 @@ func (b *ResourceBuilder) WithOperatorLabels(labels map[string]string) map[strin
 
 // CreateOperatorDeployment creates deployment
 func (b *ResourceBuilder) CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount string, numReplicas int32, podSpec corev1.PodSpec) *appsv1.Deployment {
-	labels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
-	return CreateDeployment(name, namespace, labels, labels, numReplicas, podSpec, serviceAccount, nil)
+	selectorLabels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
+	podLabels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
+	return CreateDeployment(name, namespace, selectorLabels, podLabels, numReplicas, podSpec, serviceAccount, nil)
 }
 
 // CreateDeployment creates deployment

--- a/vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources/resources.go
+++ b/vendor/kubevirt.io/controller-lifecycle-operator-sdk/pkg/sdk/resources/resources.go
@@ -37,8 +37,9 @@ func (b *ResourceBuilder) WithOperatorLabels(labels map[string]string) map[strin
 
 // CreateOperatorDeployment creates deployment
 func (b *ResourceBuilder) CreateOperatorDeployment(name, namespace, matchKey, matchValue, serviceAccount string, numReplicas int32, podSpec corev1.PodSpec) *appsv1.Deployment {
-	labels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
-	return CreateDeployment(name, namespace, labels, labels, numReplicas, podSpec, serviceAccount, nil)
+	selectorLabels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
+	podLabels := WithLabels(map[string]string{matchKey: matchValue}, b.operatorLabels)
+	return CreateDeployment(name, namespace, selectorLabels, podLabels, numReplicas, podSpec, serviceAccount, nil)
 }
 
 // CreateDeployment creates deployment


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The operator deployment's spec.selector.matchLabels changed between
versions because CreateOperatorDeployment used the same map reference
for both the selector and pod template labels. Labels added to the
pod template in 772b968 ("Add network policies to Migration Operator")
leaked into the immutable selector, causing upgrade failures. Fix the
underlying root cause by using separate maps in the sdk
(a fix that would later belong in that project).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade fails: kubevirt-migration-operator deployment spec.selector is immutable
```
